### PR TITLE
g:singleton#entrust_pattern: support submodule repo

### DIFF
--- a/autoload/singleton.vim
+++ b/autoload/singleton.vim
@@ -19,7 +19,7 @@ call s:def('g:singleton#entrust_pattern', {
 \     '/\.svn/tmp/.*\.tmp$',
 \   ],
 \   'git': [
-\     '/\.git/COMMIT_EDITMSG$',
+\     '/\.git/\%(modules/.\+/\)\?COMMIT_EDITMSG$',
 \     '/\.git/rebase-merge/.*$',
 \     '/\.git/.*\.diff$',
 \   ],


### PR DESCRIPTION
Gitのコミットメッセージ用ファイル`COMMIT_MSG`のパターン(`g:singleton#entrust_pattern`)を修正しました。
## 背景

`repo`というリポジトリの中に`subrepo`というsubmoduleリポジトリがあるとします。
`repo/subrepoA`

すると、`repo/subrepoA/.git`は以下のような内容のテキストファイルになります。

```
gitdir: ../.git/modules/subrepoA
```

場所が`repo`直下でないsubmoduleリポジトリ`repo/path/to/subrepoB`は以下のようになります。

```
gitdir: ../.git/modules/path/to/subrepoB
```

そして肝心なのが、`subrepoB`の`COMMIT_MSG`の場所は以下のようになります。

```
../.git/modules/path/to/subrepoB/COMMIT_MSG
```

よって、`COMMIT_MSG`のパターンがマッチしなくなるため、パターンを修正しました。
