### PR TITLE
Merge default values if the keys are absent

### DIFF
--- a/autoload/singleton.vim
+++ b/autoload/singleton.vim
@@ -11,9 +11,16 @@ function! s:def(var, val)
     let {a:var} = a:val
   endif
 endfunction
+function! s:def_dict(var, val)
+  if !exists(a:var)
+    let {a:var} = a:val
+  elseif type(a:val) ==# type({})
+    call extend({a:var}, a:val, 'keep')
+  endif
+endfunction
 
-call s:def('g:singleton#ignore_pattern', {})
-call s:def('g:singleton#entrust_pattern', {
+call s:def_dict('g:singleton#ignore_pattern', {})
+call s:def_dict('g:singleton#entrust_pattern', {
 \   'svn': [
 \     '/svn-\%(commit\|prop\)\%(\.\d\+\)\?\.tmp$',
 \     '/\.svn/tmp/.*\.tmp$',

--- a/doc/singleton.txt
+++ b/doc/singleton.txt
@@ -107,6 +107,7 @@ CUSTOMIZING					*singleton-customizing*
 g:singleton#ignore_pattern			*g:singleton#ignore_pattern*
 	A pattern(|singleton-pattern|) for specifying the file which should
 	be ignored.
+	Default values are merged if the keys are absent.
 	Default: empty
 
 g:singleton#entrust_pattern			*g:singleton#entrust_pattern*
@@ -114,6 +115,7 @@ g:singleton#entrust_pattern			*g:singleton#entrust_pattern*
 	be entrusted to remote Vim.
 	It means, Vim waits until remote file is closed.
 	This is useful to get along with version control systems.
+	Default values are merged if the keys are absent.
 	Default: Files for Subversion, Git, Hg, and Bazaar.
 	This is large.  See the variable directly for details.
 


### PR DESCRIPTION
以下のDictionary変数をデフォルト値でマージ可能にしました。

* g:singleton#ignore_pattern
* g:singleton#entrust_pattern

`extend(..., ..., 'keep')`を使っているので、キーがなかった場合はデフォルト値が入ります。
注意すべき点として、既存のデフォルト値もユーザの設定によって上書き可能です。