### PR TITLE
Entrust yaourt tempfiles

### DIFF
--- a/autoload/singleton.vim
+++ b/autoload/singleton.vim
@@ -26,6 +26,7 @@ call s:def('g:singleton#entrust_pattern', {
 \   ],
 \   'hg': '/hg-editor-.\{6}\.txt$',
 \   'bzr': '/bzr_log\..\{6}$',
+\   'yaourt': '^/tmp/yaourt-tmp-[^/]\+/',
 \ })
 call s:def('g:singleton#group', $USER . $USERNAME)
 call s:def('g:singleton#opener', 'tab drop')

--- a/autoload/singleton.vim
+++ b/autoload/singleton.vim
@@ -25,7 +25,7 @@ call s:def('g:singleton#entrust_pattern', {
 \     '/\.git/.*\.diff$',
 \   ],
 \   'hg': '/hg-editor-.\{6}\.txt$',
-\   'bar': '/bzr_log\..\{6}$',
+\   'bzr': '/bzr_log\..\{6}$',
 \ })
 call s:def('g:singleton#group', $USER . $USERNAME)
 call s:def('g:singleton#opener', 'tab drop')


### PR DESCRIPTION
#12 に基づいたPRです。

Arch Linuxのyaourtというパッケージマネージャで、インストールする際に`PKGBUILD`や`{pkgname}.install`といったパッケージを構築するのに必要なスクリプトを編集できますが、その際環境変数EDITORに指定されているエディタが起動します。
その際に終了を待つ必要があるので、 `g:singleton#entrust_pattern` に追加しました。